### PR TITLE
feat: support Windows builds and tests

### DIFF
--- a/src/askpass_tests.rs
+++ b/src/askpass_tests.rs
@@ -530,14 +530,19 @@ Host beta
 
 #[test]
 fn is_recent_marker_returns_false_for_nonexistent() {
-    let path = PathBuf::from("/tmp/purple_test_nonexistent_marker");
+    let path = std::env::temp_dir().join("purple_test_nonexistent_marker");
+    let _ = std::fs::remove_file(&path);
     assert!(!is_recent_marker(&path));
 }
 
 #[test]
 fn is_recent_marker_returns_true_for_fresh_file() {
-    let path = PathBuf::from("/tmp/purple_test_fresh_marker");
-    let _ = std::fs::write(&path, b"");
+    let path = std::env::temp_dir().join(format!(
+        "purple_test_fresh_marker_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&path);
+    std::fs::write(&path, b"").expect("write marker");
     assert!(is_recent_marker(&path));
     let _ = std::fs::remove_file(&path);
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -500,6 +500,7 @@ Host key verification failed.
     /// Mutex to serialise tests that mutate the TMUX env var.
     static TMUX_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    #[cfg(unix)]
     #[test]
     fn is_in_tmux_returns_true_when_set() {
         let _guard = TMUX_LOCK.lock().unwrap_or_else(|p| p.into_inner());

--- a/src/file_browser_tests.rs
+++ b/src/file_browser_tests.rs
@@ -144,9 +144,13 @@ fn test_build_scp_args_upload() {
         &["file.txt".to_string()],
         false,
     );
+    let expected_local = Path::new("/home/user/docs")
+        .join("file.txt")
+        .to_string_lossy()
+        .into_owned();
     assert_eq!(
         args,
-        vec!["--", "/home/user/docs/file.txt", "myhost:/remote/path/",]
+        vec!["--".to_string(), expected_local, "myhost:/remote/path/".to_string()]
     );
 }
 

--- a/src/fs_util.rs
+++ b/src/fs_util.rs
@@ -8,7 +8,6 @@ use log::{debug, error};
 /// The lock is released when the `FileLock` is dropped.
 pub struct FileLock {
     lock_path: PathBuf,
-    #[cfg(unix)]
     _file: fs::File,
 }
 
@@ -137,23 +136,45 @@ pub fn atomic_write(path: &Path, content: &[u8]) -> io::Result<()> {
 
     #[cfg(not(unix))]
     {
-        if let Err(e) = fs::write(&tmp_path, content) {
+        use std::io::Write;
+        // Open with write access so sync_all (FlushFileBuffers) succeeds on
+        // Windows; opening read-only and calling sync_all returns Access
+        // Denied because FlushFileBuffers requires GENERIC_WRITE.
+        let open = || {
+            fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&tmp_path)
+        };
+        let mut file = match open() {
+            Ok(f) => f,
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                let _ = fs::remove_file(&tmp_path);
+                open().map_err(|e| {
+                    io::Error::new(
+                        e.kind(),
+                        format!("Failed to create temp file {}: {}", tmp_path.display(), e),
+                    )
+                })?
+            }
+            Err(e) => {
+                return Err(io::Error::new(
+                    e.kind(),
+                    format!("Failed to create temp file {}: {}", tmp_path.display(), e),
+                ));
+            }
+        };
+        if let Err(e) = file.write_all(content) {
+            drop(file);
             let _ = fs::remove_file(&tmp_path);
             return Err(e);
         }
-        // sync_all via reopen since fs::write doesn't return a File handle
-        match fs::File::open(&tmp_path) {
-            Ok(f) => {
-                if let Err(e) = f.sync_all() {
-                    let _ = fs::remove_file(&tmp_path);
-                    return Err(e);
-                }
-            }
-            Err(e) => {
-                let _ = fs::remove_file(&tmp_path);
-                return Err(e);
-            }
+        if let Err(e) = file.sync_all() {
+            drop(file);
+            let _ = fs::remove_file(&tmp_path);
+            return Err(e);
         }
+        drop(file);
     }
 
     let result = fs::rename(&tmp_path, path);

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -40,6 +40,23 @@ fn key(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::NONE)
 }
 
+/// Build a path whose parent is a regular file, so `atomic_write`'s
+/// `create_dir_all(parent)` fails on every platform. Used to force save
+/// failures in rollback tests; portable replacement for hardcoded
+/// `/nonexistent/...` paths that silently succeed on Windows because
+/// the user can write under `C:\`.
+fn unwritable_path() -> PathBuf {
+    let blocker = std::env::temp_dir().join(format!(
+        "purple_handler_unwritable_{}_{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&blocker);
+    let _ = std::fs::remove_file(&blocker);
+    std::fs::write(&blocker, b"block").expect("write blocker file");
+    blocker.join("child").join("snippets")
+}
+
 /// App met een geconfigureerde DigitalOcean (auto_sync=true) en een nieuw Proxmox.
 fn make_providers_app_with_do() -> App {
     let mut app = make_app("Host test\n  HostName test.com\n");
@@ -3004,7 +3021,7 @@ fn test_snippet_picker_d_last_item_selects_none() {
 fn test_snippet_picker_d_rollback_on_save_failure() {
     let mut app = make_snippet_app();
     // Point to a non-writable path to force save failure
-    app.snippets.store.path_override = Some(PathBuf::from("/nonexistent/dir/snippets"));
+    app.snippets.store.path_override = Some(unwritable_path());
     let (tx, _rx) = mpsc::channel();
 
     let _ = handle_key_event(&mut app, key(KeyCode::Char('d')), &tx);
@@ -3180,7 +3197,7 @@ fn test_snippet_form_submit_rejects_duplicate_name() {
 fn test_snippet_form_submit_rollback_on_save_failure() {
     let mut app = make_snippet_app();
     // Force save failure
-    app.snippets.store.path_override = Some(PathBuf::from("/nonexistent/dir/snippets"));
+    app.snippets.store.path_override = Some(unwritable_path());
     app.snippets.form = crate::app::SnippetForm::new();
     app.snippets.form.name = "new-cmd".to_string();
     app.snippets.form.command = "whoami".to_string();
@@ -3202,7 +3219,7 @@ fn test_snippet_form_submit_rollback_on_save_failure() {
 fn test_snippet_form_edit_rename_rollback_on_save_failure() {
     let mut app = make_snippet_app();
     // Force save failure
-    app.snippets.store.path_override = Some(PathBuf::from("/nonexistent/dir/snippets"));
+    app.snippets.store.path_override = Some(unwritable_path());
     app.snippets.form =
         crate::app::SnippetForm::from_snippet(&app.snippets.store.snippets[0].clone());
     app.snippets.form.name = "renamed".to_string();

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -365,6 +365,7 @@ const MAX_OUTPUT_LINES: usize = 10_000;
 /// Uses SIGTERM first, then escalates to SIGKILL after a brief wait.
 pub struct ChildGuard {
     inner: std::sync::Mutex<Option<std::process::Child>>,
+    #[cfg_attr(not(unix), allow(dead_code))]
     pgid: i32,
 }
 

--- a/src/vault_ssh_tests.rs
+++ b/src/vault_ssh_tests.rs
@@ -4,20 +4,21 @@ use super::*;
 /// a mock `ssh-keygen` or `vault` binary. Without this, parallel tests
 /// race on the process-wide environment and one test's PATH restore
 /// overwrites another's mock.
-#[cfg(unix)]
 static PATH_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[test]
 fn cert_path_for_simple_alias() {
     let path = cert_path_for("webserver").unwrap();
-    assert!(path.ends_with("certs/webserver-cert.pub"));
-    assert!(path.to_string_lossy().contains(".purple/certs/"));
+    assert!(path.ends_with(Path::new("certs").join("webserver-cert.pub")));
+    assert!(path.ends_with(
+        Path::new(".purple").join("certs").join("webserver-cert.pub")
+    ));
 }
 
 #[test]
 fn cert_path_for_alias_with_prefix() {
     let path = cert_path_for("aws-prod-web01").unwrap();
-    assert!(path.ends_with("certs/aws-prod-web01-cert.pub"));
+    assert!(path.ends_with(Path::new("certs").join("aws-prod-web01-cert.pub")));
 }
 
 /// Regression: a public key path that contains `=` would split the
@@ -605,10 +606,13 @@ fn resolve_cert_path_uses_certificate_file_when_set() {
 #[test]
 fn resolve_cert_path_falls_back_to_default() {
     let path = resolve_cert_path("myhost", "").unwrap();
+    let suffix = Path::new(".purple")
+        .join("certs")
+        .join("myhost-cert.pub");
     assert!(
-        path.to_string_lossy()
-            .contains(".purple/certs/myhost-cert.pub"),
-        "got: {}",
+        path.ends_with(&suffix),
+        "expected suffix {}, got: {}",
+        suffix.display(),
         path.display()
     );
 }

--- a/tests/mcp_e2e.rs
+++ b/tests/mcp_e2e.rs
@@ -140,6 +140,11 @@ fn mcp_e2e_full_session() {
 // list. The unit tests for `expand_user_path` cover the function in isolation;
 // this test covers the full subprocess chain that mirrors how the .mcpb
 // bundle launches in production.
+//
+// Unix-only: on Windows `dirs::home_dir()` uses SHGetKnownFolderPath, which
+// ignores HOME/USERPROFILE env overrides, so the subprocess always reads
+// the real user profile and the test cannot redirect it to a tempdir.
+#[cfg(unix)]
 #[test]
 fn mcp_subprocess_expands_literal_home_in_args() {
     use tempfile::TempDir;


### PR DESCRIPTION
## summary

adds Windows support to purple. fixes one production bug (every config save returns Access Denied on Windows) and a handful of test-only assumptions (hardcoded `/tmp` paths, missing `cfg(unix)` gates, path-separator-coupled assertions). **no Unix code path is modified**,  only `cfg(not(unix))` branches and test setup, so existing Linux/macOS CI should continue to pass unchanged.

## production fix

`fs_util::atomic_write`'s `cfg(not(unix))` branch opened the temp file with `fs::File::open` (read-only) and called `sync_all`. on Windows `sync_all` invokes `FlushFileBuffers`, which requires `GENERIC_WRITE` access, opening read-only returns `ERROR_ACCESS_DENIED`. the result: **every config save fails on Windows** (provider config, snippets, preferences, sync history, vault cert paths).

rewrote the non-unix branch to mirror the unix one (`OpenOptions::new().write(true).create_new(true)`) so the same handle covers write + sync. same retry-on-stale-tmp logic preserved. also moved `FileLock._file` out of its `cfg(unix)` gate to match the existing `cfg(not(unix))` write site that already initialised it (otherwise the project does not even compile on Windows).

## test infrastructure

| file                    | fix                                                                                                                                                                                                                                                                                                                                                                                                                |
| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `vault_ssh_tests.rs`    | `PATH_LOCK` static was `cfg(unix)` but referenced from a non-gated test; ungated. two path-separator assertions switched to `Path::join` / `Path::ends_with`.                                                                                                                                                                                                                                                       |
| `file_browser_tests.rs` | path-separator assertion uses `Path::join` for the expected value.                                                                                                                                                                                                                                                                                                                                                  |
| `connection.rs`         | `is_in_tmux_returns_true_when_set` gated `cfg(unix)`; the function returns `false` unconditionally on non-Unix so the env override could never satisfy the assertion.                                                                                                                                                                                                                                              |
| `handler/tests.rs`      | new `unwritable_path()` helper for forcing save failures portably. replaces three uses of `/nonexistent/dir/snippets`, which on Windows resolves to `C:\nonexistent\dir\snippets` and silently succeeds because the user can write under `C:\`.                                                                                                                                                                     |
| `askpass_tests.rs`      | hardcoded `/tmp/...` → `temp_dir().join(...)`.                                                                                                                                                                                                                                                                                                                                                                      |
| `tests/mcp_e2e.rs`      | `mcp_subprocess_expands_literal_home_in_args` gated `cfg(unix)`. Windows `dirs::home_dir()` reads `SHGetKnownFolderPath(FOLDERID_Profile)` and ignores `HOME` / `USERPROFILE` env overrides, so the subprocess always read the real profile and the tempdir setup could not redirect it. the MCPB-on-Claude-Desktop scenario the test reproduces is also Unix-shell specific (Windows MCPB clients use `%USERPROFILE%`). |
| `snippet.rs`            | `ChildGuard.pgid` is only read inside `cfg(unix)`; added `cfg_attr(not(unix), allow(dead_code))` to silence the cosmetic warning.                                                                                                                                                                                                                                                                                  |

## verification

- `cargo build --release` clean on Windows (MSVC toolchain, Rust 1.95).
- `cargo test` on Windows: **6,695 passed, 0 failed**.
- diff stat: `8 files changed, 86 insertions(+), 28 deletions(-)`. all changes are confined to `cfg(not(unix))` branches or test setup; the Unix runtime path is byte-identical.
