### PR TITLE
fix(aws): send x-amz-security-token so temporary STS credentials work

### DIFF
--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -67,6 +67,11 @@ pub const AWS_REGION_GROUPS: &[(&str, usize, usize)] = &[
 struct AwsCredentials {
     access_key: String,
     secret_key: String,
+    /// `aws_session_token` / `AWS_SESSION_TOKEN`. Present for temporary
+    /// credentials (access key IDs starting with `ASIA`) issued by STS via
+    /// AssumeRole, IAM Identity Center (SSO) or GetSessionToken. Must be sent
+    /// as a signed `x-amz-security-token` header or AWS rejects the request.
+    session_token: Option<String>,
 }
 
 fn resolve_credentials(
@@ -78,12 +83,17 @@ fn resolve_credentials(
     if !profile.is_empty() {
         return read_credentials_file(profile, env);
     }
-    // Token field: ACCESS_KEY_ID:SECRET_ACCESS_KEY
-    if let Some((ak, sk)) = token.split_once(':') {
+    // Token field: ACCESS_KEY_ID:SECRET_ACCESS_KEY[:SESSION_TOKEN]
+    if let Some((ak, rest)) = token.split_once(':') {
+        let (sk, st) = match rest.split_once(':') {
+            Some((sk, st)) if !st.is_empty() => (sk, Some(st.to_string())),
+            _ => (rest, None),
+        };
         if !ak.is_empty() && !sk.is_empty() {
             return Ok(AwsCredentials {
                 access_key: ak.to_string(),
                 secret_key: sk.to_string(),
+                session_token: st,
             });
         }
     }
@@ -93,6 +103,7 @@ fn resolve_credentials(
             return Ok(AwsCredentials {
                 access_key: ak.to_string(),
                 secret_key: sk.to_string(),
+                session_token: env.aws_session_token().map(str::to_string),
             });
         }
     }
@@ -105,6 +116,7 @@ fn parse_credentials(content: &str, profile: &str) -> Option<AwsCredentials> {
     let mut in_section = false;
     let mut access_key = String::new();
     let mut secret_key = String::new();
+    let mut session_token = String::new();
 
     for line in content.lines() {
         let trimmed = line.trim();
@@ -119,6 +131,7 @@ fn parse_credentials(content: &str, profile: &str) -> Option<AwsCredentials> {
             match key.trim() {
                 "aws_access_key_id" => access_key = value.trim().to_string(),
                 "aws_secret_access_key" => secret_key = value.trim().to_string(),
+                "aws_session_token" => session_token = value.trim().to_string(),
                 _ => {}
             }
         }
@@ -130,6 +143,7 @@ fn parse_credentials(content: &str, profile: &str) -> Option<AwsCredentials> {
         Some(AwsCredentials {
             access_key,
             secret_key,
+            session_token: (!session_token.is_empty()).then_some(session_token),
         })
     }
 }
@@ -194,8 +208,21 @@ fn sign_request(
     datestamp: &str,
 ) -> String {
     let payload_hash = hex_encode(&sha256_hash(b""));
-    let canonical_headers = format!("host:{}\nx-amz-date:{}\n", host, timestamp);
-    let signed_headers = "host;x-amz-date";
+    // Canonical headers must be sorted by lowercase header name. With
+    // temporary credentials `x-amz-security-token` sorts after `x-amz-date`.
+    let (canonical_headers, signed_headers) = match &creds.session_token {
+        Some(token) => (
+            format!(
+                "host:{}\nx-amz-date:{}\nx-amz-security-token:{}\n",
+                host, timestamp, token
+            ),
+            "host;x-amz-date;x-amz-security-token",
+        ),
+        None => (
+            format!("host:{}\nx-amz-date:{}\n", host, timestamp),
+            "host;x-amz-date",
+        ),
+    };
 
     let canonical_request = format!(
         "GET\n/\n{}\n{}\n{}\n{}",
@@ -345,12 +372,14 @@ fn ec2_get(
     let auth = sign_request(creds, region, &host, &query_string, &timestamp, &datestamp);
     let url = format!("{}/?{}", endpoint, query_string);
 
-    let mut resp = agent
+    let mut req = agent
         .get(&url)
         .header("Authorization", &auth)
-        .header("x-amz-date", &timestamp)
-        .call()
-        .map_err(super::map_ureq_error)?;
+        .header("x-amz-date", &timestamp);
+    if let Some(token) = &creds.session_token {
+        req = req.header("x-amz-security-token", token);
+    }
+    let mut resp = req.call().map_err(super::map_ureq_error)?;
 
     resp.body_mut()
         .read_to_string()

--- a/src/providers/aws.rs
+++ b/src/providers/aws.rs
@@ -87,7 +87,8 @@ fn resolve_credentials(
     if let Some((ak, rest)) = token.split_once(':') {
         let (sk, st) = match rest.split_once(':') {
             Some((sk, st)) if !st.is_empty() => (sk, Some(st.to_string())),
-            _ => (rest, None),
+            Some((sk, _)) => (sk, None),
+            None => (rest, None),
         };
         if !ak.is_empty() && !sk.is_empty() {
             return Ok(AwsCredentials {

--- a/src/providers/aws_tests.rs
+++ b/src/providers/aws_tests.rs
@@ -234,7 +234,8 @@ fn test_parse_credentials_whitespace_handling() {
 
 #[test]
 fn test_parse_credentials_extra_keys_ignored() {
-    let content = "[default]\naws_access_key_id = AK\naws_secret_access_key = SK\nregion = us-east-1\n";
+    let content =
+        "[default]\naws_access_key_id = AK\naws_secret_access_key = SK\nregion = us-east-1\n";
     let creds = parse_credentials(content, "default").unwrap();
     assert_eq!(creds.access_key, "AK");
     assert_eq!(creds.secret_key, "SK");
@@ -290,6 +291,41 @@ fn test_sign_request_session_token_changes_signature() {
     let a = sign_request(&base, args.0, args.1, args.2, args.3, args.4);
     let b = sign_request(&with_token, args.0, args.1, args.2, args.3, args.4);
     assert_ne!(a, b);
+}
+
+#[test]
+fn test_resolve_credentials_env_without_session_token() {
+    let env = crate::runtime::env::Env::for_test("/tmp/x")
+        .with_var("AWS_ACCESS_KEY_ID", "AKIDEXAMPLE")
+        .with_var("AWS_SECRET_ACCESS_KEY", "SECRET");
+    let creds = resolve_credentials("", "", &env).unwrap();
+    assert_eq!(creds.access_key, "AKIDEXAMPLE");
+    assert_eq!(creds.secret_key, "SECRET");
+    assert_eq!(creds.session_token, None);
+}
+
+#[test]
+fn test_resolve_credentials_env_with_session_token() {
+    let env = crate::runtime::env::Env::for_test("/tmp/x")
+        .with_var("AWS_ACCESS_KEY_ID", "ASIAEXAMPLE")
+        .with_var("AWS_SECRET_ACCESS_KEY", "SECRET")
+        .with_var("AWS_SESSION_TOKEN", "TOKEN");
+    let creds = resolve_credentials("", "", &env).unwrap();
+    assert_eq!(creds.access_key, "ASIAEXAMPLE");
+    assert_eq!(creds.secret_key, "SECRET");
+    assert_eq!(creds.session_token.as_deref(), Some("TOKEN"));
+}
+
+#[test]
+fn test_resolve_credentials_profile_shadows_env_session_token() {
+    // A configured profile returns early, so the env fallback never runs.
+    // With no readable credentials file this is an auth failure, not a
+    // silent fall-through to the environment.
+    let env = crate::runtime::env::Env::empty()
+        .with_var("AWS_ACCESS_KEY_ID", "ASIAEXAMPLE")
+        .with_var("AWS_SECRET_ACCESS_KEY", "SECRET")
+        .with_var("AWS_SESSION_TOKEN", "TOKEN");
+    assert!(resolve_credentials("", "default", &env).is_err());
 }
 
 #[test]

--- a/src/providers/aws_tests.rs
+++ b/src/providers/aws_tests.rs
@@ -318,14 +318,26 @@ fn test_resolve_credentials_env_with_session_token() {
 
 #[test]
 fn test_resolve_credentials_profile_shadows_env_session_token() {
-    // A configured profile returns early, so the env fallback never runs.
-    // With no readable credentials file this is an auth failure, not a
-    // silent fall-through to the environment.
-    let env = crate::runtime::env::Env::empty()
-        .with_var("AWS_ACCESS_KEY_ID", "ASIAEXAMPLE")
-        .with_var("AWS_SECRET_ACCESS_KEY", "SECRET")
-        .with_var("AWS_SESSION_TOKEN", "TOKEN");
-    assert!(resolve_credentials("", "default", &env).is_err());
+    // A configured profile wins over the environment, so every field comes
+    // from the credentials file even when both sources are populated.
+    let home = tempfile::tempdir().expect("tempdir");
+    let aws_dir = home.path().join(".aws");
+    std::fs::create_dir_all(&aws_dir).expect("create .aws");
+    std::fs::write(
+        aws_dir.join("credentials"),
+        "[default]\naws_access_key_id = ASIAFROMFILE\naws_secret_access_key = FILESECRET\naws_session_token = FILETOKEN\n",
+    )
+    .expect("write credentials file");
+
+    let env = crate::runtime::env::Env::for_test(home.path())
+        .with_var("AWS_ACCESS_KEY_ID", "ASIAFROMENV")
+        .with_var("AWS_SECRET_ACCESS_KEY", "ENVSECRET")
+        .with_var("AWS_SESSION_TOKEN", "ENVTOKEN");
+
+    let creds = resolve_credentials("", "default", &env).expect("profile resolves from file");
+    assert_eq!(creds.access_key, "ASIAFROMFILE");
+    assert_eq!(creds.secret_key, "FILESECRET");
+    assert_eq!(creds.session_token.as_deref(), Some("FILETOKEN"));
 }
 
 #[test]
@@ -339,6 +351,17 @@ fn test_resolve_credentials_token_with_session_token() {
     assert_eq!(creds.access_key, "ASIAEXAMPLE");
     assert_eq!(creds.secret_key, "SECRET");
     assert_eq!(creds.session_token.as_deref(), Some("TOKEN"));
+}
+
+#[test]
+fn test_resolve_credentials_token_trailing_separator() {
+    // An empty third component leaves the secret key intact and yields no
+    // session token.
+    let creds = resolve_credentials("AKID:SECRET:", "", &crate::runtime::env::Env::empty())
+        .expect("access key and secret are both present");
+    assert_eq!(creds.access_key, "AKID");
+    assert_eq!(creds.secret_key, "SECRET");
+    assert_eq!(creds.session_token, None);
 }
 
 #[test]
@@ -1069,4 +1092,100 @@ fn fetch_from_maps_auth_failure_to_provider_error() {
         matches!(result, Err(ProviderError::AuthFailed)),
         "a 401 from the region must surface as AuthFailed, got {result:?}"
     );
+}
+
+#[test]
+fn fetch_sends_security_token_header_for_temporary_credentials() {
+    // Both EC2 calls must carry x-amz-security-token, because the signature
+    // declares it in SignedHeaders.
+    let mut server = mockito::Server::new();
+    let instances = server
+        .mock("GET", "/")
+        .match_query(mockito::Matcher::UrlEncoded(
+            "Action".into(),
+            "DescribeInstances".into(),
+        ))
+        .match_header("x-amz-security-token", "TOKEN")
+        .with_status(200)
+        .with_header("content-type", "text/xml")
+        .with_body(
+            r#"<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+  <reservationSet><item><instancesSet><item>
+    <instanceId>i-1234567890</instanceId>
+    <instanceState><name>running</name></instanceState>
+    <ipAddress>54.1.2.3</ipAddress>
+    <imageId>ami-12345678</imageId>
+    <tagSet><item><key>Name</key><value>web-1</value></item></tagSet>
+  </item></instancesSet></item></reservationSet>
+</DescribeInstancesResponse>"#,
+        )
+        .create();
+    let images = server
+        .mock("GET", "/")
+        .match_query(mockito::Matcher::UrlEncoded(
+            "Action".into(),
+            "DescribeImages".into(),
+        ))
+        .match_header("x-amz-security-token", "TOKEN")
+        .with_status(200)
+        .with_header("content-type", "text/xml")
+        .with_body(
+            r#"<DescribeImagesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+  <imagesSet><item><imageId>ami-12345678</imageId><name>amzn2-ami-hvm-2.0</name></item></imagesSet>
+</DescribeImagesResponse>"#,
+        )
+        .create();
+
+    let aws = Aws {
+        regions: vec!["us-east-1".to_string()],
+        profile: String::new(),
+    };
+    let url = server.url();
+    let hosts = aws
+        .fetch_with_endpoint(
+            |_region| url.clone(),
+            "ASIAEXAMPLE:SECRET:TOKEN",
+            &AtomicBool::new(false),
+            &crate::runtime::env::Env::empty(),
+            &|_| {},
+        )
+        .expect("a signed request carrying the session token must reach the mock");
+    instances.assert();
+    images.assert();
+    assert_eq!(hosts.len(), 1);
+}
+
+#[test]
+fn fetch_omits_security_token_header_for_static_credentials() {
+    // Long-lived keys sign without the token, so the header must be absent.
+    let mut server = mockito::Server::new();
+    let instances = server
+        .mock("GET", "/")
+        .match_query(mockito::Matcher::Any)
+        .match_header("x-amz-security-token", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_header("content-type", "text/xml")
+        .with_body(
+            r#"<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+  <reservationSet></reservationSet>
+</DescribeInstancesResponse>"#,
+        )
+        .create();
+
+    let aws = Aws {
+        regions: vec!["us-east-1".to_string()],
+        profile: String::new(),
+    };
+    let url = server.url();
+    let hosts = aws
+        .fetch_with_endpoint(
+            |_region| url.clone(),
+            "AKID:SECRET",
+            &AtomicBool::new(false),
+            &crate::runtime::env::Env::empty(),
+            &|_| {},
+        )
+        .expect("static credentials must reach the mock without a token header");
+    instances.assert();
+    assert!(hosts.is_empty());
 }

--- a/src/providers/aws_tests.rs
+++ b/src/providers/aws_tests.rs
@@ -122,6 +122,7 @@ fn test_sign_request_format() {
     let creds = AwsCredentials {
         access_key: "AKIDEXAMPLE".to_string(),
         secret_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".to_string(),
+        session_token: None,
     };
     let auth = sign_request(
         &creds,
@@ -143,6 +144,7 @@ fn test_sign_request_deterministic() {
     let creds = AwsCredentials {
         access_key: "AK".to_string(),
         secret_key: "SK".to_string(),
+        session_token: None,
     };
     let a = sign_request(
         &creds,
@@ -168,6 +170,7 @@ fn test_sign_request_different_regions() {
     let creds = AwsCredentials {
         access_key: "AK".to_string(),
         secret_key: "SK".to_string(),
+        session_token: None,
     };
     let a = sign_request(
         &creds,
@@ -231,10 +234,75 @@ fn test_parse_credentials_whitespace_handling() {
 
 #[test]
 fn test_parse_credentials_extra_keys_ignored() {
-    let content = "[default]\naws_access_key_id = AK\naws_secret_access_key = SK\naws_session_token = TOKEN\nregion = us-east-1\n";
+    let content = "[default]\naws_access_key_id = AK\naws_secret_access_key = SK\nregion = us-east-1\n";
     let creds = parse_credentials(content, "default").unwrap();
     assert_eq!(creds.access_key, "AK");
     assert_eq!(creds.secret_key, "SK");
+    assert_eq!(creds.session_token, None);
+}
+
+#[test]
+fn test_parse_credentials_session_token() {
+    let content = "[default]\naws_access_key_id = ASIAEXAMPLE\naws_secret_access_key = SK\naws_session_token = TOKEN\n";
+    let creds = parse_credentials(content, "default").unwrap();
+    assert_eq!(creds.access_key, "ASIAEXAMPLE");
+    assert_eq!(creds.secret_key, "SK");
+    assert_eq!(creds.session_token.as_deref(), Some("TOKEN"));
+}
+
+#[test]
+fn test_sign_request_includes_security_token_when_present() {
+    let creds = AwsCredentials {
+        access_key: "ASIAEXAMPLE".to_string(),
+        secret_key: "SK".to_string(),
+        session_token: Some("TOKEN".to_string()),
+    };
+    let auth = sign_request(
+        &creds,
+        "eu-central-1",
+        "ec2.eu-central-1.amazonaws.com",
+        "Action=DescribeInstances&Version=2016-11-15",
+        "20240101T000000Z",
+        "20240101",
+    );
+    assert!(auth.contains("SignedHeaders=host;x-amz-date;x-amz-security-token,"));
+}
+
+#[test]
+fn test_sign_request_session_token_changes_signature() {
+    let base = AwsCredentials {
+        access_key: "ASIAEXAMPLE".to_string(),
+        secret_key: "SK".to_string(),
+        session_token: None,
+    };
+    let with_token = AwsCredentials {
+        access_key: "ASIAEXAMPLE".to_string(),
+        secret_key: "SK".to_string(),
+        session_token: Some("TOKEN".to_string()),
+    };
+    let args = (
+        "eu-central-1",
+        "ec2.eu-central-1.amazonaws.com",
+        "Action=DescribeInstances",
+        "20240101T000000Z",
+        "20240101",
+    );
+    let a = sign_request(&base, args.0, args.1, args.2, args.3, args.4);
+    let b = sign_request(&with_token, args.0, args.1, args.2, args.3, args.4);
+    assert_ne!(a, b);
+}
+
+#[test]
+fn test_resolve_credentials_token_with_session_token() {
+    let creds = resolve_credentials(
+        "ASIAEXAMPLE:SECRET:TOKEN",
+        "",
+        &crate::runtime::env::Env::empty(),
+    )
+    .unwrap();
+    assert_eq!(creds.access_key, "ASIAEXAMPLE");
+    assert_eq!(creds.secret_key, "SECRET");
+    assert_eq!(creds.session_token.as_deref(), Some("TOKEN"));
 }
 
 #[test]

--- a/src/runtime/env.rs
+++ b/src/runtime/env.rs
@@ -208,6 +208,11 @@ impl Env {
         }
     }
 
+    /// `AWS_SESSION_TOKEN`, set alongside temporary STS credentials.
+    pub fn aws_session_token(&self) -> Option<&str> {
+        self.var("AWS_SESSION_TOKEN")
+    }
+
     /// `PURPLE_TOKEN`, the self-invocation auth token.
     pub fn purple_token(&self) -> Option<&str> {
         self.var("PURPLE_TOKEN")

--- a/src/runtime/env.rs
+++ b/src/runtime/env.rs
@@ -375,6 +375,23 @@ mod tests {
     }
 
     #[test]
+    fn aws_session_token_reads_env_var() {
+        let env = Env::for_test("/tmp/x");
+        assert_eq!(env.aws_session_token(), None);
+        let with_token = env.with_var("AWS_SESSION_TOKEN", "TOKEN");
+        assert_eq!(with_token.aws_session_token(), Some("TOKEN"));
+    }
+
+    #[test]
+    fn aws_session_token_is_independent_of_key_pair() {
+        // Temporary credentials always arrive as a triple, but the accessor
+        // must not depend on the key pair being present.
+        let env = Env::for_test("/tmp/x").with_var("AWS_SESSION_TOKEN", "TOKEN");
+        assert_eq!(env.aws_credentials(), None);
+        assert_eq!(env.aws_session_token(), Some("TOKEN"));
+    }
+
+    #[test]
     fn active_proxy_vars_filters_empty_and_orders() {
         let env = Env::for_test("/tmp/x")
             .with_var("HTTPS_PROXY", "http://proxy:3128")


### PR DESCRIPTION

## Problem

AWS EC2 sync fails with `AWS EC2: Authentication failed. Check your API token.` for anyone whose credentials come from STS — IAM Identity Center (SSO), `assume-role`, `get-session-token` or any corporate federation wrapper. The request is signed and sent; EC2 rejects it.

The cause is in `src/providers/aws.rs`:

1. `AwsCredentials` has only `access_key` and `secret_key`. There is no field for a session token.
2. `parse_credentials` matches `aws_access_key_id` and `aws_secret_access_key` and drops everything else via `_ => {}`, so `aws_session_token` in `~/.aws/credentials` is silently discarded. `test_parse_credentials_extra_keys_ignored` currently asserts this behaviour.
3. `sign_request` hardcodes `signed_headers = "host;x-amz-date"` and `ec2_get` sends only `Authorization` and `x-amz-date`.

SigV4 with temporary credentials requires the session token to be sent as `x-amz-security-token` *and* included in the canonical request and `SignedHeaders`. Without it AWS cannot validate the signature, so every `ASIA...` credential fails 100% of the time regardless of expiry, region or IAM policy. Only long-lived `AKIA` keys work today — which is exactly the credential type most organisations prohibit.

Reproduce: configure the AWS provider with a profile whose credentials came from `aws sts assume-role` or SSO, then `purple --verbose sync`.

## Fix

- Add `session_token: Option<String>` to `AwsCredentials`.
- Read `aws_session_token` in `parse_credentials`.
- Read `AWS_SESSION_TOKEN` in the env-var fallback, via a new `Env::aws_session_token()` accessor alongside the existing `Env::aws_credentials()`.
- Accept an optional third component in the inline token field: `ACCESS_KEY_ID:SECRET_ACCESS_KEY[:SESSION_TOKEN]`. Two-part tokens keep working unchanged; secret access keys are base64 and never contain `:`, so the split is unambiguous.
- In `sign_request`, when a session token is present, add `x-amz-security-token` to the canonical headers and to `SignedHeaders`. Header order is preserved: canonical headers must be sorted by lowercase name, and `x-amz-security-token` sorts after `x-amz-date`.
- In `ec2_get`, send the `x-amz-security-token` header when present.

The `None` branch is byte-identical to the previous behaviour, so signatures for long-lived `AKIA` credentials are unchanged.

## Tests

- `test_parse_credentials_extra_keys_ignored` reworded — it no longer uses `aws_session_token` as its example of an ignored key, and now asserts `session_token == None` for a profile without one.
- `test_parse_credentials_session_token` — token is parsed from the profile.
- `test_resolve_credentials_token_with_session_token` — three-part inline token.
- `test_sign_request_includes_security_token_when_present` — `SignedHeaders=host;x-amz-date;x-amz-security-token`.
- `test_sign_request_session_token_changes_signature` — the token actually enters the signature rather than just being appended as a header.

Existing `sign_request` tests updated with `session_token: None` and still assert `SignedHeaders=host;x-amz-date`.

## Notes

- Docs: the AWS section of the Cloud Providers wiki page lists the auth options; `--token AKID:SECRET` there could be updated to `--token AKID:SECRET[:SESSION_TOKEN]`.
- Worth considering separately: `resolve_credentials` returns early on `if !profile.is_empty()`, so a configured-but-unreadable profile fails without ever reaching the token or env branches. That is defensible, but it means the documented env-var fallback never applies to anyone with a profile configured, which is surprising in practice.
- Unrelated but adjacent: temporary credentials expire, often within the hour. Once this lands, a failed sync on stale credentials will still surface as a generic auth error. A distinct message for expired-vs-invalid would save users a lot of guessing.
